### PR TITLE
Fix escape bug, when building page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
 ## List of projects using esp82xx
 
  - [Colorchord](https://github.com/cnlohr/colorchord)
+ - [esp8266ws2812i2c](https://github.com/cnlohr/esp8266ws2812i2s)
+ - [espusb](https://github.com/cnlohr/espusb)
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -6,24 +6,43 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
 
  - [Colorchord](https://github.com/cnlohr/colorchord)
 
-### Notes
+## Notes
 
- - Outline make a new project:
-```
-git init project_name
-cd project_name
-git submodule add git@github.com:cnlohr/esp82xx.git
-cp esp28xx/user.cfg.example user.cfg
-cp esp28xx/Makefile.example Makefile
-mkdir -p web/page
-mkdir user
-ln -s esp28xx/web/Makefile web/
-```
-Then link, edit and copy to your heart's content. See [esp82XX-basic](https://github.com/con-f-use/esp82XX-basic) for a minimal example.
+ - Do not forget to use the `--recursive` option when cloning a porject with submodules like this
+
+ - Cope with submodules updates:
+    - Changes in the submodule:
+
+        cd esp82xx
+        # Make changes
+        git commit -m 'Your Message'
+        git push
+
+    - Then bump the version in the main project root folder:
+
+        cd ..
+        git submodule updates
+        git add esp82xx
+        git commit -m 'Bumped submodule version'
+        git push
+
+ - Outline to make a new project:
+
+        git init project_name
+        cd project_name
+        git submodule add git@github.com:cnlohr/esp82xx.git
+        cp esp28xx/user.cfg.example user.cfg
+        cp esp28xx/Makefile.example Makefile
+        mkdir -p web/page
+        mkdir user
+        ln -s esp28xx/web/Makefile web/
+
+    Then link, edit and copy to your heart's content. See [esp82XX-basic](https://github.com/con-f-use/esp82XX-basic) for a minimal example.
 
  - You should **not** include binaries in the project repository itself.
- There is a make target that builds the binaries and creates a zip file that can be included with the release.
- To make a release, just tag a commit with `git tag -a 'v1.3.3.7'` and push the tag with `git push --tags`.
- After that, the github webinterface will allow you to make a release out of the new tag and include the binary file. 
- To make the zip file invoke `make projectname-version-binaries.zip` (Tab-autocomplete is your friend).
+    There is a make target that builds the binaries and creates a `.tar` file that can be included with the release.
+    To make a release, just tag a commit with `git tag -a 'v1.3.3.7' -m 'Your release caption'` and push the tag with `git push --tags`.
+
+    After that, the github web-interface will allow you to make a release out of the new tag and include the binary file.
+    To make the zip file invoke `make projectname-version-binaries.tgz` (Tab-autocomplete is your friend).
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -18,10 +18,10 @@ page.mpfs : mfsmaker $(wildcard page/*) Makefile
 	$(RM) -r tmp
 	$(CP) -r page tmp
 	$(info $(PROJECT_URL))
-	sed -i 's/{{PAGE_TITLE}}/$(subst ",,$(PAGE_TITLE))/' tmp/index.html
-	sed -i 's/{{PAGE_SCRIPT}}/$(subst ",,$(PAGE_SCRIPT))/' tmp/index.html
-	sed -i 's/{{PAGE_HEADING}}/$(subst ",,$(PAGE_HEADING))/' tmp/index.html
-	sed -i 's/{{PAGE_INFO}}/$(subst ",,$(PAGE_INFO))/' tmp/index.html
+	sed -i 's/{{PAGE_TITLE}}/$(subst /,\/,$(PAGE_TITLE))/' tmp/index.html
+	sed -i 's/{{PAGE_SCRIPT}}/$(subst /,\/,$(PAGE_SCRIPT))/' tmp/index.html
+	sed -i 's/{{PAGE_HEADING}}/$(subst /,\/,$(PAGE_HEADING))/' tmp/index.html
+	sed -i 's/{{PAGE_INFO}}/$(subst /,\/,$(PAGE_INFO))/' tmp/index.html
 	sed -i 's/{{VERSSTR}}/$(subst ",,$(VERSSTR))/' tmp/index.html
 	sed -i 's/{{PROJECT_URL}}/$(subst ",,$(subst /,\/,$(PROJECT_URL)))/' tmp/index.html
 	sed -i 's/{{PROJECT_NAME}}/$(subst ",,$(PROJECT_NAME))/' tmp/index.html


### PR DESCRIPTION
Little bug when building page from template variables in `user.cfg` now fixed (slashes need too be escaped for `sed`). In the long run the sed command's should be replaced by a proper templating program.