### PR TITLE
Closes #9: Automatically get submodules also re-enable shell sdk variable, various readme stuff

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -1,11 +1,22 @@
 include user.cfg
-include esp82xx/common.mf
-include esp82xx/main.mf
+-include esp82xx/common.mf
+-include esp82xx/main.mf
+
+ifndef TARGET
+# Fetch submodule if the user forgot to clone with `--recursive`
+GETSUBMODS = all burn burnweb netweb netburn clean cleanall purge
+.PHONY : $(GETSUBMODS)
+$(GETSUBMODS) :
+    $(warning Submodule esp82xx was not fetched. Trying it now.)
+    git submodule update --init --recursive
+    $(info Re-unning make...)
+    make $@ $(MFLAGS) $(MAKEOVERRIDES)
+endif
 
 # Example for a custom rule.
 # Most of the build is handled in main.mf
 .PHONY : showvars
-showvars: 
+showvars:
 	$(foreach v, $(.VARIABLES), $(info $(v) = $($(v))))
 	true
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate projects.
 
+## Usage
+
+ - `user.cfg` specifies a few configuration variables. Most notably the location of the Espressif SDK for building the firmware. You can edit `DEFAULT_SDK` there to reflect your specific path or **even better** define a shell variable `export ESP_ROOT=/path/to/sdk` in your `.bashrc`, `.profile` or where-ever. You can also pass the location as an argument to make:
+
+   ```
+   make burn ESP_ROOT=path/to/sdk
+   ```
+
 ## List of projects using esp82xx
 
  - [esp82XX-basic](https://github.com/con-f-use/esp82XX-basic)
@@ -55,3 +63,8 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
     After that, the github web-interface will allow you to make a release out of the new tag and include the binary file.
     To make the zip file invoke `make projectname-version-binaries.tgz` (Tab-autocomplete is your friend).
 
+### To do
+
+ - Include libraries for usb, ws2812s and ethernet
+
+ - Expand this readme

--- a/README.md
+++ b/README.md
@@ -13,20 +13,25 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
  - Do not forget to use the `--recursive` option when cloning a porject with submodules like this
 
  - Cope with submodules updates:
+
     - Changes in the submodule:
 
+        ```
         cd esp82xx
         # Make changes
         git commit -m 'Your Message'
         git push
+        ```
 
     - Then bump the version in the main project root folder:
 
+        ```
         cd ..
         git submodule updates
         git add esp82xx
         git commit -m 'Bumped submodule version'
         git push
+        ```
 
  - Outline to make a new project:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
 
 ## List of projects using esp82xx
 
+ - [esp82XX-basic](https://github.com/con-f-use/esp82XX-basic)
  - [Colorchord](https://github.com/cnlohr/colorchord)
  - [esp8266ws2812i2c](https://github.com/cnlohr/esp8266ws2812i2s)
  - [espusb](https://github.com/cnlohr/espusb)
+ - Migration of others in progress
 
 ## Notes
 

--- a/common.mf
+++ b/common.mf
@@ -6,7 +6,7 @@
 
 GCC_FOLDER = $(ESP_ROOT)/xtensa-lx106-elf
 ESPTOOL_PY = $(ESP_ROOT)/esptool/esptool.py
-SDK        ?= $(ESP_ROOT)/sdk
+SDK        = $(ESP_ROOT)/sdk
 
 XTLIB        = $(SDK)/lib
 XTGCCLIB     = $(GCC_FOLDER)/lib/gcc/xtensa-lx106-elf/$(ESP_GCC_VERS)/libgcc.a
@@ -21,6 +21,7 @@ CP           = cp
 # Derived Options
 ###############################################################################
 
+SDK_DEFAULT = $(HOME)/esp8266/esp-open-sdk
 OPTS += -DWEB_PORT=$(WEB_PORT) -DCOM_PORT=$(COM_PORT) -DBACKEND_PORT=$(BACKEND_PORT) $(EXTRAOPTS)
 ESP_ROOT := $(shell echo "$$ESP_ROOT")
 ifeq ($(strip $(ESP_ROOT)),)


### PR DESCRIPTION
## Changes

 - Add what was talked about in #9 
 - Re-enable specifying the path to the SDK in a convenient shell variable (e.g. in `.bash_aliases` or `.bashrc`)¹
 - Expand on the README a little bit.

------------------

¹ @cnlohr disabled this feature (accidentally?) in 69105918bbac375a5ff7126203851dede2b1ae27, did it cause problems?