### PR TITLE
Expand readme and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,65 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
 
 ## Usage
 
- - `user.cfg` specifies a few configuration variables. Most notably the location of the Espressif SDK for building the firmware. You can edit `DEFAULT_SDK` there to reflect your specific path or **even better** define a shell variable `export ESP_ROOT=/path/to/sdk` in your `.bashrc`, `.profile` or where-ever. You can also pass the location as an argument to make:
+First, check out a project that uses esp82xx
 
-   ```
-   make burn ESP_ROOT=path/to/sdk
-   ```
+    git clone --recursive https://github.com/con-f-use/esp82XX-basic
+
+or create your own
+
+    git init project_name
+    cd project_name
+    git submodule add git@github.com:cnlohr/esp82xx.git
+    cp esp28xx/user.cfg.example user.cfg
+    cp esp28xx/Makefile.example Makefile
+    mkdir -p web/page user
+    ln -s esp28xx/web/Makefile web/
+    # ... link or copy more files depending on how much you want to change ...
+
+After you have the basic file structure in place, you should edit `user.cfg` in the top level.
+**Do not** edit files in `./esp82xx`. 
+You should rather copy them to top-level directories and edit/include the copies where necessary.
+The basic Makefile for the firmware is `./esp82xx/main.mf`.
+Most things can be achieved by including it and changing some make variables like this:
+
+    include esp82xx/main.mf
+
+    SRCS += more_sources.c # Add your project specific sources
+    ....
+
+The file  `user.cfg` specifies the most important configuration variables. 
+Most notably the location of the Espressif SDK for building the firmware. 
+You will need a working copy of that. 
+We recommend the excellent [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk) by @pfalcon to download and install all necessary tools.
+Here is a shell script to [download and build](https://gist.github.com/con-f-use/d086ca941c2c80fbde6d8996b8a50761) a version known to work.
+Some versions of the SDK are somewhat problematic, e.g. with SDK versions greater than 1.5.2, Espressif changed the IRAM management, so some projects began to hit size restrictions and would not compile.
+
+You can edit `DEFAULT_SDK` in user.cfg to reflect your specific SDK path or **even better** define a shell variable `export ESP_ROOT=/path/to/sdk` in your `.bashrc`, `.profile` or what-ever is used in your shell. 
+You can also pass the location as an argument to make:
+
+   make all ESP_ROOT=path/to/sdk
+
+If you did everything correctly, flashing your esp should work.
+Just connect it to an USB to serial adaptor that uses 3.3V (you will fry your ESP with higer voltages) and place it in programming mode.
+Then you can run
+
+   make burn
+   make burnweb
+
+and your ESP is good to go.
+It should create its own WiFi Access Point called `ESPXXXX` or similar, where `XXXX` is some number.
+From now on you can configure and burn new firmware/page data over the web interface in your browser (when connected to the esp's network or it is connected to yours).
+There are make targets to burn firmware and page data as well:
+
+    make netburn IP=192.168.1.4  # default IP, change to whatever your ESP is set to
+    make netweb IP=192.168.1.4
+
+You can [connect to the ESP](http://cn8266.local) in your browser
+
+    http://cn8266.local
+
+There is also a make-target called `getips` and the ESP will print its connection info to the serial interface.
+
 
 ## List of projects using esp82xx
 
@@ -36,28 +90,16 @@ Useful ESP8266 C Environment. Intended to be included as sub-modules in derivate
     - Then bump the version in the main project root folder:
 
         ```
+        cd esp82xx
+        git pull
         cd ..
-        git submodule updates
         git add esp82xx
         git commit -m 'Bumped submodule version'
         git push
         ```
 
- - Outline to make a new project:
-
-        git init project_name
-        cd project_name
-        git submodule add git@github.com:cnlohr/esp82xx.git
-        cp esp28xx/user.cfg.example user.cfg
-        cp esp28xx/Makefile.example Makefile
-        mkdir -p web/page
-        mkdir user
-        ln -s esp28xx/web/Makefile web/
-
-    Then link, edit and copy to your heart's content. See [esp82XX-basic](https://github.com/con-f-use/esp82XX-basic) for a minimal example.
-
  - You should **not** include binaries in the project repository itself.
-    There is a make target that builds the binaries and creates a `.tar` file that can be included with the release.
+    There is a make target that builds the binaries and creates a `.zip` file. Included that in the release.
     To make a release, just tag a commit with `git tag -a 'v1.3.3.7' -m 'Your release caption'` and push the tag with `git push --tags`.
 
     After that, the github web-interface will allow you to make a release out of the new tag and include the binary file.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or create your own
     # ... link or copy more files depending on how much you want to change ...
 
 After you have the basic file structure in place, you should edit `user.cfg` in the top level.
-**Do not** edit files in `./esp82xx`. 
+**Do not** edit files in `./esp82xx`.
 You should rather copy them to top-level directories and edit/include the copies where necessary.
 The basic Makefile for the firmware is `./esp82xx/main.mf`.
 Most things can be achieved by including it and changing some make variables like this:
@@ -28,26 +28,25 @@ Most things can be achieved by including it and changing some make variables lik
     include esp82xx/main.mf
 
     SRCS += more_sources.c # Add your project specific sources
-    ....
 
-The file  `user.cfg` specifies the most important configuration variables. 
-Most notably the location of the Espressif SDK for building the firmware. 
-You will need a working copy of that. 
+The file  `user.cfg` specifies the most important configuration variables.
+Most notably the location of the Espressif SDK for building the firmware.
+You will need a working copy of that.
 We recommend the excellent [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk) by @pfalcon to download and install all necessary tools.
 Here is a shell script to [download and build](https://gist.github.com/con-f-use/d086ca941c2c80fbde6d8996b8a50761) a version known to work.
 Some versions of the SDK are somewhat problematic, e.g. with SDK versions greater than 1.5.2, Espressif changed the IRAM management, so some projects began to hit size restrictions and would not compile.
 
-You can edit `DEFAULT_SDK` in user.cfg to reflect your specific SDK path or **even better** define a shell variable `export ESP_ROOT=/path/to/sdk` in your `.bashrc`, `.profile` or what-ever is used in your shell. 
+You can edit `DEFAULT_SDK` in user.cfg to reflect your specific SDK path or **even better** define a shell variable `export ESP_ROOT=/path/to/sdk` in your `.bashrc`, `.profile` or what-ever is used in your shell.
 You can also pass the location as an argument to make:
 
-   make all ESP_ROOT=path/to/sdk
+    make all ESP_ROOT=path/to/sdk
 
 If you did everything correctly, flashing your esp should work.
 Just connect it to an USB to serial adaptor that uses 3.3V (you will fry your ESP with higer voltages) and place it in programming mode.
 Then you can run
 
-   make burn
-   make burnweb
+    make burn
+    make burnweb
 
 and your ESP is good to go.
 It should create its own WiFi Access Point called `ESPXXXX` or similar, where `XXXX` is some number.
@@ -74,36 +73,56 @@ There is also a make-target called `getips` and the ESP will print its connectio
 
 ## Notes
 
- - Do not forget to use the `--recursive` option when cloning a porject with submodules like this
+This section should mostly concern developers and contributors to this project.
 
- - Cope with submodules updates:
+#### Branches
 
-    - Changes in the submodule:
+If you make small incremental changes and/or experimental ones, push to the `dev` branch rahter than to origin/master:
 
-        ```
-        cd esp82xx
-        # Make changes
-        git commit -m 'Your Message'
-        git push
-        ```
+   git push origin dev
 
-    - Then bump the version in the main project root folder:
+You can merge or squash-merge them into `master` once they have been tested and enough changes accumulate.
 
-        ```
-        cd esp82xx
-        git pull
-        cd ..
-        git add esp82xx
-        git commit -m 'Bumped submodule version'
-        git push
-        ```
+    # ... Make changes in dev ...
+    # ... test them and be sure they should go into master ...
+    git checkout master
+    git merge --squash dev
+    git commit
 
- - You should **not** include binaries in the project repository itself.
-    There is a make target that builds the binaries and creates a `.zip` file. Included that in the release.
-    To make a release, just tag a commit with `git tag -a 'v1.3.3.7' -m 'Your release caption'` and push the tag with `git push --tags`.
+It might be good to create feature brances to develop individual features and merge them to dev and then from there to master or a hotfix branch for important quick-fixes.
 
-    After that, the github web-interface will allow you to make a release out of the new tag and include the binary file.
-    To make the zip file invoke `make projectname-version-binaries.tgz` (Tab-autocomplete is your friend).
+#### Submodule Updates
+
+Cope with submodules in top-level projects updates:
+
+ - Changes in the submodule:
+
+    ```
+    cd esp82xx
+    # Make changes
+    git commit -m 'Your Message'
+    git push
+    ```
+
+ - Then bump the version in the main project root folder:
+
+    ```
+    cd esp82xx
+    git pull
+    cd ..
+    git add esp82xx
+    git commit -m 'Bumped submodule version'
+    git push
+    ```
+
+#### Include Binaries
+
+You should **not** include binaries in the project repository itself.
+There is a make target that builds the binaries and creates a `.zip` file. Included that in the release.
+To make a release, just tag a commit with `git tag -a 'v1.3.3.7' -m 'Your release caption'` and push the tag with `git push --tags`.
+
+After that, the github web-interface will allow you to make a release out of the new tag and include the binary file.
+To make the zip file invoke `make projectname-version-binaries.tgz` (Tab-autocomplete is your friend).
 
 ### To do
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This section should mostly concern developers and contributors to this project.
 
 If you make small incremental changes and/or experimental ones, push to the `dev` branch rahter than to origin/master:
 
-   git push origin dev
+    git push origin dev
 
 You can merge or squash-merge them into `master` once they have been tested and enough changes accumulate.
 
@@ -128,4 +128,3 @@ To make the zip file invoke `make projectname-version-binaries.tgz` (Tab-autocom
 
  - Include libraries for usb, ws2812s and ethernet
 
- - Expand this readme

--- a/main.mf
+++ b/main.mf
@@ -49,6 +49,11 @@ LINKFLAGS = $(LDFLAGS_CORE) -B$(XTLIB)
 
 BIN_TARGET = $(PROJECT_NAME)-$(VERSION)-binaries.zip
 
+ifneq (,$(findstring -DDEBUG,$(OPTS)))
+$(warning Debug is enabled!)
+FLASH_WRITE_FLAGS += --verify
+endif
+
 ##########################################################################RULES
 
 help :
@@ -69,10 +74,10 @@ debug : $(TARGET)
 
 ifeq ($(CHIP), 8285)
 burn : $(FW_FILE1) $(FW_FILE2)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else ifeq ($(CHIP), 8266)
 burn : $(FW_FILE1) $(FW_FILE2)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else
 	$(error Error: Unknown chip '$(CHIP)')
 endif

--- a/main.mf
+++ b/main.mf
@@ -105,7 +105,7 @@ getips:
 	sudo nmap -sP 192.168.0.0/24 | grep -iP "espressif|esp" -B2 | grep -oP "(\d{1,3}\.){3,3}\d\d{1,3}"
 
 clean :
-	$(RM) $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRCS))) $(TARGET) image.map image.lst
+	$(RM) $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRCS))) $(TARGET) image.map image.lst $(CLEAN_EXTRA)
 
 purge : clean
 	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) clean


### PR DESCRIPTION
I expanded the readme a bit and added useful information.

I also created this `dev` branch, We can commit to it, if we don't want to risk changing the `master` branch. I think it is a good idea at this point. We can test code and discuss stuff here, before we change the (somewhat) stable `master` branch. Also if we merge with the `--squash` option, we don't clod the commit history of master with many commits that just changed small things. They will just exist in `dev` and master will see one large commit. See notes in the expanded readme.

This also gives Charles a way to review changes.

Hope, @cnlohr thinks this is a good idea. I think we could almost tag one of the near-future commits with a version number like `v0.8` and mark it 'stable', 'recommended' or 'pre-release', if we cared to.