### PR TITLE
Added -fm dio into make burn for NodeMCU and some ESP-12E boards

### DIFF
--- a/main.mf
+++ b/main.mf
@@ -81,7 +81,7 @@ burn : $(FW_FILE1) $(FW_FILE2)
 	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else ifeq ($(CHIP), 8266)
 burn : $(FW_FILE1) $(FW_FILE2)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else
 	$(error Error: Unknown chip '$(CHIP)')
 endif


### PR DESCRIPTION
Hi, I would like to request for PR to resolve an issue faced in NodeMCU while I was doing for espusb #https://github.com/cnlohr/espusb/issues/3

This issue is stated inside the esptool docs [https://github.com/themadinventor/esptool/tree/4deca7033e17d9b8d3b947a2d8f7ec3700d7d276#flash-mode---flash_mode--fm](url)

```Some ESP8266 modules, including the ESP-12E modules on some (not all) NodeMCU boards, are dual I/O and will only work with --flash_mode dio.```

I'm not sure whether you guys prefer to have another if-else checker to check the chip model e.g. "8285,8266,NodeMCU" but currently I'm just adding ```-fm dio``` into the 8266 chip since I've tested this against other ESP8266 and it seems to work well.