### PR TITLE
Add gzip MIME types and delocalize build date

### DIFF
--- a/common.mf
+++ b/common.mf
@@ -40,7 +40,7 @@ endif
 
 # Version related stuff
 VERSION := $(shell git describe --abbrev=5 --dirty=-dev --always --tags)
-VERSSTR := "Version: $(VERSION) - Build $(shell date) with $(OPTS)"
+VERSSTR := "Version: $(VERSION) - Build $(shell date -R) with $(OPTS)"
 PROJECT_NAME := $(notdir $(shell git rev-parse --show-toplevel))
 PROJECT_URL := $(subst .com:,.com/,$(subst .git,,$(subst git@,https://,$(shell git config --get remote.origin.url))))
 


### PR DESCRIPTION
CSS needs to be sent with the MIME type text/css or else most browsers will refuse to use it. This change will enable use of pre-compressed css files.

The -R switch to date makes the date appear the same on all locales (RFC-2822).

My editor also took the liberty and removed some spaces in the file so the diff is a bit messier than I'd like.
I also forgot to make the changes to the dev branch, but after some git gymnastics I think I've fixed it. I added the latest change from master (62ab44e)  too since it was too messy to not include it.
