### PR TITLE
Fix OTA upgrade bug and repair saving WiFi credentials

### DIFF
--- a/fwsrc/commonservices.c
+++ b/fwsrc/commonservices.c
@@ -560,6 +560,7 @@ CMD_RET_TYPE cmd_WiFi(char * buffer, int retsize, char * pusrdata, char *buffend
 
 
 CMD_RET_TYPE cmd_Flash(char * buffer, int retsize, char *pusrdata, unsigned short len, char * buffend) {
+	uint32 chip_size_saved = flashchip->chip_size;
 	flashchip->chip_size = 0x01000000;
 	int nr = ParamCaptureAndAdvanceInt();
 
@@ -627,15 +628,15 @@ CMD_RET_TYPE cmd_Flash(char * buffer, int retsize, char *pusrdata, unsigned shor
 			//siz = size to write.
 			//colon2 = data start.
 			if( colon2 && (nr >= FLASH_PROTECTION_BOUNDARY || ( nr >= 0x10000 && nr < 0x30000 ) ) ) {
-				colon2++;
-                debug( "FX%d\t%d", nr, siz );
+				//colon2++;
+				debug( "FX%d\t%d", nr, siz );
 				int datlen = ((int)len - (colon2 - pusrdata))/2;
 				if( datlen > siz ) datlen = siz;
 
 				for( i = 0; i < datlen; i++ ) {
 					int8_t r1, r2;
 					r1 = fromhex1( *(colon2++) );
-                    r2 = fromhex1( *(colon2++) );
+					r2 = fromhex1( *(colon2++) );
 					if( r1 == -1 || r2 == -1 ) goto failfx;
 					buffend[i] = (r1 << 4) | r2;
 				}
@@ -683,7 +684,7 @@ CMD_RET_TYPE cmd_Flash(char * buffer, int retsize, char *pusrdata, unsigned shor
 		break;
 	}
 
-	flashchip->chip_size = 0x00080000;
+	flashchip->chip_size = chip_size_saved;
 	return buffend - buffer;
 } // END: cmd_Flash(...)
 

--- a/fwsrc/mfs.c
+++ b/fwsrc/mfs.c
@@ -12,6 +12,7 @@ void ICACHE_FLASH_ATTR FindMPFS()
 {
 	uint32 mfs_check[2];
 	EnterCritical();
+	uint32 chip_size_saved = flashchip->chip_size;
 	flashchip->chip_size = 0x01000000;
 
 	spi_flash_read( MFS_START, mfs_check, sizeof( mfs_check ) );
@@ -26,7 +27,7 @@ void ICACHE_FLASH_ATTR FindMPFS()
 
 done:
 	printf( "MFS Found at: %08x\n", mfs_at );
-	flashchip->chip_size = 0x00080000;
+	flashchip->chip_size = chip_size_saved;
 	ExitCritical();
 }
 
@@ -48,6 +49,7 @@ int8_t ICACHE_FLASH_ATTR MFSOpenFile( const char * fname, struct MFSFileInfo * m
 	}
 
 	EnterCritical();
+	uint32 chip_size_saved = flashchip->chip_size;
 	flashchip->chip_size = 0x01000000;
 	uint32 ptr = mfs_at;
 	struct MFSFileEntry e;
@@ -61,12 +63,12 @@ int8_t ICACHE_FLASH_ATTR MFSOpenFile( const char * fname, struct MFSFileInfo * m
 		{
 			mfi->offset = e.start;
 			mfi->filelen = e.len;
-			flashchip->chip_size = 0x00080000;
+			flashchip->chip_size = chip_size_saved;
 			ExitCritical();
 			return 0;
 		}
 	}
-	flashchip->chip_size = 0x00080000;
+	flashchip->chip_size = chip_size_saved;
 	ExitCritical();
 	return -1;
 }
@@ -83,9 +85,10 @@ int32_t ICACHE_FLASH_ATTR MFSReadSector( uint8_t* data, struct MFSFileInfo * mfi
 	if( toread > MFS_SECTOR ) toread = MFS_SECTOR;
 
 	EnterCritical();
+	uint32 chip_size_saved = flashchip->chip_size;
 	flashchip->chip_size = 0x01000000;
 	spi_flash_read( mfs_at+mfi->offset, (uint32*)data, MFS_SECTOR ); //TODO: should we make this toread?  maybe toread rounded up?
-	flashchip->chip_size = 0x00080000;
+	flashchip->chip_size = chip_size_saved;
 	ExitCritical();
 
 	mfi->offset += toread;


### PR DESCRIPTION
1. removed skipping one byte from firmware sent by web
2. size of flash chip now not hardcoded, will be restored correctly, so system parameters will be saved for all flash sizes, not only for 512K