### PR TITLE
Devfixes

### DIFF
--- a/common.mf
+++ b/common.mf
@@ -43,7 +43,7 @@ endif
 # Version related stuff
 VCMD = git describe --abbrev=5 --dirty=-dev --always --tags 2>/dev/null                                          
 VERSION := $(shell $(VCMD) || { cd esp82xx 2>/dev/null; $(VCMD) ; } ||  echo "unknown")
-VERSSTR := "Version: $(VERSION) - Build $(shell date -R) with $(OPTS)"
+VERSSTR := "Version: $(VERSION) - Build $(shell LANG=en_us_8859_1 date '+%a, %b %e %Y, %R:%S %z') with $(OPTS)"
 PROJECT_NAME := $(notdir $(shell git rev-parse --show-toplevel 2>/dev/null || echo "exp82xx-project"))
 PROJECT_URL := $(subst .com:,.com/,$(subst .git,,$(subst git@,https://,$(shell git config --get remote.origin.url 2>/dev/null || echo "https://github.com/con-f-use/esp82xx-basic.git"))))
 


### PR DESCRIPTION
Hi Charles, 

These changes fix the issue #66    esp82xx and  colorchord issues 45 and 46. 

As we discussed then, some fix bugs that are part of esp82xx
The rest fix the bugs that appear when using esp82xx with colorchord. 
These are fixed by more calls to EnterCritical() and ExitCritical(). 
(so using esp82xx in other situations when the above routines do nothing wont mess things up)
However, a refactoring will be due as the naming them Enter and Exit Critical is a bit misleading, as for colorchord it is a way to ensure the HPATimer is off at the right time. 