### PR TITLE
Update README.md so it use python 3 instead of python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ You will need the following:
  * Install Ubuntu 20.04: https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71?rtc=1
  * Launch Ubuntu 20.04
  * Proceed with normal prerequisites and project.
- * Uninstall Python 3 (`sudo apt purge python3`)
+ * Install Python 2 and make separately
+ ```
+ sudo apt update
+ sudo apt install python2 make
+ ```
 
 #### Prerequisites (Debian, Mint, Ubuntu):
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo apt-get install -y make gcc g++ gperf install-info gawk libexpat-dev python
 Note: Some platforms do not have python-serial.  If they don't have it, do this:
 ```
 curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
-sudo python2 get-pip.py
+sudo python3 get-pip.py
 pip install pyserial
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You will need the following:
  * Install Ubuntu 20.04: https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71?rtc=1
  * Launch Ubuntu 20.04
  * Proceed with normal prerequisites and project.
- * Uninstall Python 3 ('sudo apt purge python3')
+ * Uninstall Python 3 (`sudo apt purge python3`)
 
 #### Prerequisites (Debian, Mint, Ubuntu):
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You will need the following:
  * Install Python 2 and make separately
  ```
  sudo apt update
- sudo apt install python2 make
+ sudo apt install python make
  ```
 
 #### Prerequisites (Debian, Mint, Ubuntu):


### PR DESCRIPTION
Using python 3 instead of python 2 when installing pip, as it's EOL has been reached.
https://www.python.org/doc/sunset-python-2
Also WSL only have python 3 shipped with it.