### PR TITLE
Install make and python separately on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ You will need the following:
  * Reboot.
  * Install Ubuntu 20.04: https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71?rtc=1
  * Launch Ubuntu 20.04
+ * Install Python 2 and make separately
+ ```
+ sudo apt update
+ sudo apt install python make
+ ```
  * Proceed with normal prerequisites and project.
 
 #### Prerequisites (Debian, Mint, Ubuntu):


### PR DESCRIPTION
WSL somehow does not want to install python and make when installing with other program. So i suggest install it separately from other program by `sudo apt install python make`

![00](https://user-images.githubusercontent.com/36285359/91656527-8f3f7d80-eae3-11ea-81f1-3f8ec1a053bc.png)
![01](https://user-images.githubusercontent.com/36285359/91656529-92d30480-eae3-11ea-9517-9a7f49f57f7f.png)
![11](https://user-images.githubusercontent.com/36285359/91656530-949cc800-eae3-11ea-9837-8ed47a3c1eb6.png)

```
jinodk@JINODK:~$ sudo apt-get install -y make gcc g++ gperf install-info gawk libexpat-dev python-dev python python-serial sed git unzip bash wget bzip2 libtool-bin
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libexpat1-dev' instead of 'libexpat-dev'
Note, selecting 'python-dev-is-python2' instead of 'python-dev'
Note, selecting 'python-is-python2' instead of 'python'
E: Unable to locate package python-serial
jinodk@JINODK:~$ make

Command 'make' not found, but can be installed with:

sudo apt install make        # version 4.2.1-1.2, or
sudo apt install make-guile  # version 4.2.1-1.2

jinodk@JINODK:~$ python
python.exe    python3       python3.8     python3.dll   python3.exe   python37.dll  pythonw.exe
jinodk@JINODK:~$ sudo apt install python make
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'python-is-python2' instead of 'python'
The following additional packages will be installed:
  python2 python2-minimal python2.7 python2.7-minimal
Suggested packages:
  make-doc python2-doc python-tk python2.7-doc binutils binfmt-support
The following NEW packages will be installed:
  make python-is-python2 python2 python2-minimal python2.7 python2.7-minimal
0 upgraded, 6 newly installed, 0 to remove and 26 not upgraded.
Need to get 1770 kB of archives.
After this operation, 4911 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
[...]
jinodk@JINODK:~$ make
make: *** No targets specified and no makefile found.  Stop.
jinodk@JINODK:~$ python
python        python2       python3       python3.dll   python37.dll
python.exe    python2.7     python3.8     python3.exe   pythonw.exe
```