### PR TITLE
improve release/zip targets, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+libgcc_stripped.a

--- a/Makefile.example
+++ b/Makefile.example
@@ -1,3 +1,6 @@
+# by default, project name is set from the name of the root directory. override it here if you like
+# PROJECT_NAME=TheCoolestProjectYet
+
 include user.cfg
 -include esp82xx/common.mf
 -include esp82xx/main.mf

--- a/common.mf
+++ b/common.mf
@@ -62,8 +62,9 @@ endif
 # Version related stuff
 VCMD = git describe --abbrev=5 --dirty=-dev --always --tags 2>/dev/null                                          
 VERSION := $(shell $(VCMD) || { cd esp82xx 2>/dev/null; $(VCMD) ; } ||  echo "unknown")
-VERSSTR := "Version: $(VERSION) - Build $(shell LANG=en_us_8859_1 date '+%a, %b %e %Y, %R:%S %z') with $(OPTS)"
-PROJECT_NAME := $(notdir $(shell git rev-parse --show-toplevel 2>/dev/null || echo "exp82xx-project"))
+BUILD_DATE := $(shell LANG=en_us_8859_1 date '+%a, %b %e %Y, %R:%S %z')
+VERSSTR := "Version: $(VERSION) - Build $(BUILD_DATE) with $(OPTS)"
+PROJECT_NAME := $(or $(PROJECT_NAME),$(notdir $(shell git rev-parse --show-toplevel 2>/dev/null || echo "exp82xx-project")))
 PROJECT_URL := $(subst .com:,.com/,$(subst .git,,$(subst git@,https://,$(shell git config --get remote.origin.url 2>/dev/null || echo "https://github.com/con-f-use/esp82xx-basic.git"))))
 
 # Newline and space hacks

--- a/main.mf
+++ b/main.mf
@@ -1,45 +1,46 @@
 define USAGE
 Usage: make [command] [VARIABLES]
 
-all......... Build the binaries
-clean....... Clean the binaries
-purge....... Clean the binaries and web stuff
-debug....... Build a .map and .lst file.  Useful for seeing what's going on
-             behind the scenes.
-burn ....... Write firmware to chip using a regular serial port
-burn_cutecom Write firmware to chip using a regular serial port, killing and
-             starting cutecom, a serial terminal
-build_burn . Build the binaries then execute burn_cutecom
-burnweb .... Write data for the Web-GUI to chip using a regular serial
-             port
-netburn .... Same as 'burn' but transfer firmware over the network rather
-             than the serial port (if supported by the existing firmware
-             on the chip)
-netweb ..... Same as 'burnweb' but transfer data over network if supported
-             by firmware currently on the chip
-getips ..... Get a list with IPs of esp82xxs connected to your network
-project .... Make the current working direcotry an esp82xx project
-gitproject . Same as 'make project' but also initialiezes the current folder
-             as git repository and pushes it to GIT_ORIGIN.
-             Example:
-                 make gitproject GIT_ORIGIN=https://github.com/USER/YREPO.git
-cleanproject Remove the use* and web folders
-usbburn .... Burn via PRE-RELEASE USB loader (will probably change)
-usbweb ..... Burn webpage by PRE-RELEASE USB loader (will probably change)
-initdefault  Burn default initial data to ROM (may be needed after erase)
-init3v3 .... Burn default values to rom but for use with system_get_vdd33
-erase ...... Totally erase chip.
-wipechip.... Write zeros to the chip
-getips ..... Detect pssible IPs for ESP82XX modules, needs nmap, takes time
-burnitall .. initdefault + burnweb + burn as a single run.
-dumprom .... read the rom from the chip
-bump_submodule . Update the git submodules
+all .......... Build the binaries
+clean ........ Clean the binaries
+purge ........ Clean the binaries and web stuff
+debug ........ Build a .map and .lst file.  Useful for seeing what's going on
+               behind the scenes.
+burn ......... Write firmware to chip using a regular serial port
+burn_cutecom . Write firmware to chip using a regular serial port, killing and
+               starting cutecom, a serial terminal
+build_burn ... Build the binaries then execute burn_cutecom
+burnweb ...... Write data for the Web-GUI to chip using a regular serial
+               port
+netburn ...... Same as 'burn' but transfer firmware over the network rather
+               than the serial port (if supported by the existing firmware
+               on the chip)
+netweb ....... Same as 'burnweb' but transfer data over network if supported
+               by firmware currently on the chip
+project ...... Make the current working direcotry an esp82xx project
+gitproject ... Same as 'make project' but also initialiezes the current folder
+               as git repository and pushes it to GIT_ORIGIN.
+               Example:
+                   make gitproject GIT_ORIGIN=https://github.com/USER/YREPO.git
+cleanproject . Remove the use* and web folders
+usbburn ...... Burn via PRE-RELEASE USB loader (will probably change)
+usbweb ....... Burn webpage by PRE-RELEASE USB loader (will probably change)
+initdefault .. Burn default initial data to ROM (may be needed after erase)
+init3v3 ...... Burn default values to rom but for use with system_get_vdd33
+erase ........ Totally erase chip.
+wipechip...... Write zeros to the chip
+getips ....... Detect pssible IPs for ESP82XX modules, needs nmap, takes time
+burnitall .... initdefault + burnweb + burn as a single run.
+dumprom ...... read the rom from the chip
+bump_submodule Update the git submodules
+build_dir .... Create a directory named build/ with all release binaries/web stuff
+zip_build .... Create a zipfile from build_dir/ ready for release
 
 
 More commands: all, clean, purge, dumprom, cleanproject
 endef
 
-.PHONY : all clean purge netburn burnweb burn $(BIN_TARGET) netweb getips help project gitproject cleanproject build_burn burn_cutecom webmpfs
+.PHONY : 	all clean purge netburn burnweb burn netweb getips help project gitproject cleanproject build_burn burn_cutecom $(BIN_TARGET) webmpfs build_dir zip_build version.txt
 
 
 FW_FILE1 = image.elf-0x00000.bin
@@ -130,6 +131,13 @@ $(FW_FILE1) $(FW_FILE2) : $(TARGET)
 	PATH=$(FOLDERPREFIX):$$PATH $(ESPTOOL_PY) elf2image $(TARGET)
 	@#no need to set things like dout, and memory size.  This data is copied from the ESP back to itself on write.
 
+version.txt :
+	@echo VERSION=$(VERSION) > version.txt
+	@echo BUILD_DATE=$(BUILD_DATE) >> version.txt
+	@echo PROJECT_NAME=$(PROJECT_NAME) >> version.txt
+	@echo PROJECT_URL=$(PROJECT_URL) >> version.txt
+	@echo VERSSTR=$(VERSSTR) >> version.txt
+
 $(TARGET) : $(SRCS) Makefile $(SDK_DEP) $(XTGCCLIB)
 	$(CC) $(CFLAGS) $(SRCS) -flto $(LINKFLAGS) -o $@
 
@@ -140,11 +148,11 @@ debug : $(TARGET)
 
 ifeq ($(CHIP), 8285)
 burn : $(FW_FILE1) $(FW_FILE2)
-	$(info NOTICE: Currently burning for ESP8285.  If you are on a '66 reconfigure CHIP.)
+	$(info NOTICE: Currently burning for ESP8285.  If you are on an esp8266 reconfigure CHIP.)
 	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
 burn_cutecom:
 	-killall cutecom
-	$(info NOTICE: Currently burning for ESP8285.  If you are on a '66 reconfigure CHIP.)
+	$(info NOTICE: Currently burning for ESP8285.  If you are on an esp8266 reconfigure CHIP.)
 	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
 	-cutecom &
 burnitall : $(FW_FILE1) $(FW_FILE2) $(SDK)/bin/blank.bin $(INIT_DATA_ROM) webmpfs
@@ -153,11 +161,11 @@ burnitall : $(FW_FILE1) $(FW_FILE2) $(SDK)/bin/blank.bin $(INIT_DATA_ROM) webmpf
 else ifeq ($(CHIP), 8266)
 
 burn : $(FW_FILE1) $(FW_FILE2)
-	$(info NOTICE: Currently burning for ESP8266.  If you are on an '85 reconfigure CHIP.)
+	$(info NOTICE: Currently burning for ESP8266.  If you are on an esp8285 reconfigure CHIP.)
 	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
 burn_cutecom:
 	-killall cutecom
-	$(info NOTICE: Currently burning for ESP8266.  If you are on an '85 reconfigure CHIP.)
+	$(info NOTICE: Currently burning for ESP8266.  If you are on an esp8285 reconfigure CHIP.)
 	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
 	-cutecom &
 burnitall : $(FW_FILE1) $(FW_FILE2) $(SDK)/bin/blank.bin $(INIT_DATA_ROM) webmpfs
@@ -189,13 +197,19 @@ usbburn : $(FW_FILE1) $(FW_FILE2)
 usbweb : $(FW_FILE1) $(FW_FILE2)
 	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) usbpush
 
-$(BIN_TARGET): $(FW_FILE1) $(FW_FILE2)
+# files to put in the build/ dir and/or in the final .zip for release
+BUILD_FILES=$(FW_FILE1) $(FW_FILE2) web/execute_reflash web/mfsmaker web/pushtodev web/page.mpfs version.txt
+
+build_dir : $(FW_FILE1) $(FW_FILE2) version.txt webmpfs
 	@cd web \
-	 && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) page.mpfs \
 	 && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) execute_reflash \
 	 && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) pushtodev \
 	 && cd ..
-	zip $@ $(FW_FILE1) $(FW_FILE2) web/execute_reflash web/mfsmaker web/pushtodev web/page.mpfs
+	@mkdir -p ./build/
+	@cp -rf --parents ${BUILD_FILES} ./build/
+
+zip_build : build_dir
+	zip -qr - ./build/ > $(BIN_TARGET)
 
 wipechip :
 	dd if=/dev/zero of=/tmp/zeroes bs=16M count=1
@@ -207,7 +221,7 @@ getips :
 	sudo nmap -sP 192.168.0.0/24 | grep -iP "espressif|esp" -B2 | grep -oP "(\d{1,3}\.){3,3}\d\d{1,3}"
 
 clean :
-	$(RM) $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRCS))) $(TARGET) image.map image.lst $(CLEAN_EXTRA)
+	$(RM) $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRCS))) $(TARGET) image.map image.lst $(CLEAN_EXTRA) version.txt output.map esp82xx/libgcc_stripped.a
 
 dumprom :
 	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) read_flash 0 1048576 dump.bin)||(true)
@@ -223,7 +237,8 @@ erase:
 
 purge : clean
 	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) clean
-	$(RM) $(FW_FILE1) $(FW_FILE2) $(BIN_TARGET)
+	$(RM) $(FW_FILE1) $(FW_FILE2) $(BIN_TARGET) ./*-binaries.zip
+	$(RM) -rf ./build/
 
 bump_submodule :
 	cd esp82xx; git pull origin master; git submodule update --init --recursive; cd ..

--- a/web/Makefile
+++ b/web/Makefile
@@ -34,4 +34,5 @@ usbpush : pushtodev page.mpfs
 	./pushtodev USB $(MFS_PAGE_OFFSET) page.mpfs
 
 clean :
-	$(RM) mfsmaker page.mpfs pushtodev execute_reflash tmp/*
+	$(RM) mfsmaker page.mpfs pushtodev execute_reflash
+	$(RM) -r tmp/


### PR DESCRIPTION
**main**: improve zipfile output steps
- new target 'zip_release' (more human-friendly alias for $(BIN_TARGET))
- allow overriding PROJECT_NAME (useful if doing CI builds / docker and the mounted directory name is generic)
- add new target 'build_dir' which copies stuff going into the release zip into a dir named build/ first (easier to inspect/zip)
- for release/zip builds, create a version.txt with the makefile version#'s/date in it

**other/cleanup:**
- web: clean: remove tmp/ dir (previously we just removed the directory contents and not the directory itself)
- add to .gitignore: libgcc_stripped.a (happens if building with STRIPPED_LIBGCC)
- split out BUILD_DATE var for easier access
- cleanup Makefile documentation a bit
- lint: fix syntax warnings with single quotes in "if you are on a '66 reconfigure CHIP"
- zip command always overwrites the file completely instead of appeding
- fix various issues with clean and purge not quite getting everything

---
I'm not super-familiar with how projects are using BIN_TARGET or any of the other stuff, so if anything here breaks other existing projects, let me know, I can modify. I would think it's all pretty compatible though.  I'm also a little weak on my Makefile-fu, so if I'm doing anything silly, let me know.

---
# Unrelated stuff
Figured I'd just throw this over here, in case useful for anyone.

I made the above Makefile changes as part of a docker-based CI buildsystem for esp8266 projects. It seems to be working well so far. If interested, I could try to get this setup better / documented for general use.

1. I have a Docker build that implements the instructions from @cnlohr involving this toolchain: https://github.com/cnlohr/esp82xx_bin_toolchain/raw/master/esp-open-sdk-x86_64-20200810.tar.xz

It's available here in this branch:
https://github.com/Unit-e/esp-open-sdk-docker/blob/cnlohr-use-esp82xx-prebuilt/Dockerfile

I'll be updating the instructions soon on that, the docker image is available pre-built on github packages here for use with 'docker pull'
https://github.com/Unit-e/esp-open-sdk-docker/pkgs/container/esp-open-sdk-docker

So you can do something like this (I have some helper scripts that make this more of a one-liner)
```
# run the following from any host with docker installed (tested on WSL2, native windows, native linux)

# pull the image (run once)
docker pull ghcr.io/unit-e/esp-open-sdk-docker:cnlohr-use-esp82xx-prebuilt

# build an esp82xx project in the docker container.
cd SomeEsp82xxProject/

# run "make all" with Docker:
# mount the working directory from the host OS (i.e. windows) into the docker container, and run the makefile there. 
# (note: this $PWD assumes no spaces in the path). here PWD might be something like C:\projects\SomeEsp82xxProject\
docker run --rm -it -v ${PWD}:/home/build/src ghcr.io/unit-e/esp-open-sdk-docker:cnlohr-use-esp82xx-prebuilt /bin/bash -c "make all"
```

The big limitation to be aware of is, on WSL2 (which is what Docker Desktop on windows uses behind the scenes), serial port forwarding is broken so you can't just flash using the normal methods from inside the docker container. BUT, it's pretty simple to use pyserial's rfc2177 serial-over-ip server to deal with that:

In the makefile (or override on commandline or user.cfg), you set this:
```
# set serial port name to forwarding to the windows host over the internal network: (using special address host.docker.internal)
PORT  = rfc2217://host.docker.internal:4000?ign_set_control
```
And on the windows host you do something like this:
```
# listen on port 4000 and control COM7
./esp_rfc2217_server.exe -v -p 4000 COM7
```

Then all the "make burn" etc works from inside the docker container. pyserial's "miniterm" supports connect for serial monitor like this:
```
miniterm rfc2217://your-hostname-here
```

2. Separately, there is a different [but totally untested and probably problematic] docker build up here that builds the latest esp-open-sdk and puts it in a docker container.  That's at: https://github.com/Unit-e/esp-open-sdk-docker/tree/master

I made a few forks of the various submodules that fix some build issues with the latest build based on pfalcon/esp-open-sdk.  It appears to compile correctly and produce working firmware, but, I think esp82xx would be needed to be upgraded and tested to see if everything works there.

Anyway, if anyone here was ever looking to upgrade esp82xx to the latest pfalcon-based esp-open-sdk, that might be a good starting point.

---

Just wanted to shoutout to @cnlohr who has been a good sport about walking my n00b self through a lot of this for the first time.