### PR TITLE
fix exit codes for esptool

### DIFF
--- a/main.mf
+++ b/main.mf
@@ -141,27 +141,27 @@ debug : $(TARGET)
 ifeq ($(CHIP), 8285)
 burn : $(FW_FILE1) $(FW_FILE2)
 	$(info NOTICE: Currently burning for ESP8285.  If you are on a '66 reconfigure CHIP.)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))
 burn_cutecom:
 	-killall cutecom
 	$(info NOTICE: Currently burning for ESP8285.  If you are on a '66 reconfigure CHIP.)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash $(FLASH_WRITE_FLAGS) -fs 8m -fm dout 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))
 	-cutecom &
 burnitall : $(FW_FILE1) $(FW_FILE2) $(SDK)/bin/blank.bin $(INIT_DATA_ROM) webmpfs
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fs 8m -fm dout $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2) $(MFS_PAGE_OFFSET) web/page.mpfs $(BLANK_DATA_PLACE1) $(SDK)/bin/blank.bin $(INIT_DATA_PLACE) $(INIT_DATA_ROM) $(BLANK_DATA_PLACE2) $(SDK)/bin/blank.bin)||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fs 8m -fm dout $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2) $(MFS_PAGE_OFFSET) web/page.mpfs $(BLANK_DATA_PLACE1) $(SDK)/bin/blank.bin $(INIT_DATA_PLACE) $(INIT_DATA_ROM) $(BLANK_DATA_PLACE2) $(SDK)/bin/blank.bin)
 
 else ifeq ($(CHIP), 8266)
 
 burn : $(FW_FILE1) $(FW_FILE2)
 	$(info NOTICE: Currently burning for ESP8266.  If you are on an '85 reconfigure CHIP.)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))
 burn_cutecom:
 	-killall cutecom
 	$(info NOTICE: Currently burning for ESP8266.  If you are on an '85 reconfigure CHIP.)
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2))
 	-cutecom &
 burnitall : $(FW_FILE1) $(FW_FILE2) $(SDK)/bin/blank.bin $(INIT_DATA_ROM) webmpfs
-	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2) $(BLANK_DATA_PLACE1) $(SDK)/bin/blank.bin $(INIT_DATA_PLACE) $(INIT_DATA_ROM) $(BLANK_DATA_PLACE2) $(SDK)/bin/blank.bin $(MFS_PAGE_OFFSET) web/page.mpfs)||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS) --port $(PORT) write_flash -fm dio $(FLASH_WRITE_FLAGS) 0x00000 $(FW_FILE1) 0x10000 $(FW_FILE2) $(BLANK_DATA_PLACE1) $(SDK)/bin/blank.bin $(INIT_DATA_PLACE) $(INIT_DATA_ROM) $(BLANK_DATA_PLACE2) $(SDK)/bin/blank.bin $(MFS_PAGE_OFFSET) web/page.mpfs)
 else
 	$(error Error: Unknown chip '$(CHIP)')
 endif
@@ -170,7 +170,7 @@ webmpfs :
 	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) clean page.mpfs  #Always rebuild page.mpfs
 
 burnweb : webmpfs
-	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) write_flash $(MFS_PAGE_OFFSET) web/page.mpfs)||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) write_flash $(MFS_PAGE_OFFSET) web/page.mpfs)
 #If you have space, MFS should live at 0x100000. It can also live at
 #0x10000. But, then it is limited to 180kB. You might need to do this if
 # you have a 512kB, or 1M ESP variant.
@@ -199,7 +199,7 @@ $(BIN_TARGET): $(FW_FILE1) $(FW_FILE2)
 
 wipechip :
 	dd if=/dev/zero of=/tmp/zeroes bs=16M count=1
-	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) write_flash 0x0 /tmp/zeroes)||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) write_flash 0x0 /tmp/zeroes)
 
 getips :
 	$(info Detecting possible IPs for ESP82XX modules...)
@@ -210,7 +210,7 @@ clean :
 	$(RM) $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRCS))) $(TARGET) image.map image.lst $(CLEAN_EXTRA)
 
 dumprom :
-	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) read_flash 0 1048576 dump.bin)||(true)
+	($(ESPTOOL_PY) $(FWBURNFLAGS)  --port $(PORT) read_flash 0 1048576 dump.bin)
 
 initdefault :
 	$(ESPTOOL_PY) $(BURNFLAGS) --port $(PORT) write_flash $(INIT_DATA_PLACE) $(INIT_DATA_ROM)


### PR DESCRIPTION
- cnlohr backstory: once, esptool didn't report exit codes correctly
- this would cause the makefiles to fail, so the '||true' was added as a workfaround
- when testing with current esptool, doesn't look like we need this anymore
- those overrides were removed

If anyone still needs them in place, feel free to ignore this PR